### PR TITLE
fix: Fix arrays, add new opcodes STORE, ASTORE, ALOAD

### DIFF
--- a/src/compiler/grammar.jison
+++ b/src/compiler/grammar.jison
@@ -257,9 +257,7 @@ const_type:
 };
 
 @goto_f: {
-    yy.ir.quadruplesManager.pushGoToF(
-        yy.ir.quadruplesManager.getQuadrupleValue(yy.ir.quadruplesManager.getQuadruplesSize() - 1, 3)
-    );
+    yy.ir.quadruplesManager.pushGoToF(yy.ir.operands.pop());
 };
 
 @goto: {
@@ -401,7 +399,7 @@ destruct:
 
 assign:
     variable assignment_op_l1 expression {
-        yy.ir.processOperator($2);
+        yy.ir.processAssignment($2);
     };
 
 read:

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ const TYPES = Object.freeze({
   FLOAT: 'FLOAT',
   STRING: 'STRING',
   VOID: 'VOID',
+  ADDRESS: 'ADDRESS',
 });
 
 const OPCODES = Object.freeze({
@@ -14,8 +15,9 @@ const OPCODES = Object.freeze({
   GOTO_F: 'GOTO_F',
   RETURN: 'RETURN',
   INIT: 'INIT',
-  ADDROFF_ADD: 'ADDROFF_ADD',
-  ADDROFF_MULTIPLY: 'ADDROFF_MULTIPLY',
+  STORE: 'STORE',
+  ASTORE: 'ASTORE',
+  ALOAD: 'ALOAD',
 });
 
 const OPERATORS = Object.freeze({
@@ -189,6 +191,10 @@ const MEMORY_TYPES = Object.freeze({
   STACK: 'STACK',
 });
 
+const MEMORY_FLAGS = Object.freeze({
+  ADDRESS_REFERENCE: 1 << 26,
+});
+
 module.exports = {
   TYPES,
   OPCODES,
@@ -197,4 +203,5 @@ module.exports = {
   TTO_CUBE,
   OPERATOR_FUNCTIONS,
   MEMORY_TYPES,
+  MEMORY_FLAGS,
 };

--- a/src/intermediate-representation.js
+++ b/src/intermediate-representation.js
@@ -87,7 +87,7 @@ class IntermediateRepresentation {
     const callable = scopeManager.findAlias(alias);
     quadruplesManager.pushAir();
     for (const { address } of callable.args) {
-      const operand = this.operands.pop();
+      const operand = this.popAddress();
       quadruplesManager.pushAssign(address, operand, address);
     }
     quadruplesManager.pushCall(callable.start);
@@ -191,7 +191,7 @@ class IntermediateRepresentation {
     const scopeManager = this.getScopeManager();
     const currentFunction = scopeManager.getCurrentFunction();
     const returnAddress = !this.operands.isEmpty()
-      ? this.operands.pop()
+      ? this.popAddress()
       : undefined;
     const addressDetails = scopeManager.addressDetails(returnAddress);
     if (currentFunction.isVoid() && !returnAddress) {

--- a/src/memory-manager.js
+++ b/src/memory-manager.js
@@ -1,4 +1,4 @@
-const { MEMORY_TYPES, TYPES } = require('./constants');
+const { MEMORY_TYPES, TYPES, MEMORY_FLAGS } = require('./constants');
 const Memory = require('./memory');
 
 /**
@@ -31,12 +31,20 @@ const Memory = require('./memory');
  * We can access the memory scope just by shifting and masking
  * address >>> 27 & 0x7
  *
+ * The next bit represents if the address is a reference to
+ * another address
+ * 00000X00 00000000 00000000 0000000
+ * 0 = Variable Reference
+ * 1 = Address Reference
+ * We can check if it's an address reference with
+ * address >>> 26 & 0x1
+ *
  * That leaves the rest of the bits available for addresses
- * 00000XXX XXXXXXXX XXXXXXXX XXXXXXXX
- * That means we have a total of 2^27 addresses to use,
- * a total of 134,217,728 usable addresses
+ * 000000XX XXXXXXXX XXXXXXXX XXXXXXXX
+ * That means we have a total of 2^26 addresses to use,
+ * a total of 67,108,864 usable addresses
  * We can get the raw address with
- * address & 0x7FFFFFF
+ * address & 0x3FFFFFF
  */
 
 class MemoryManager {
@@ -80,7 +88,11 @@ class MemoryManager {
   }
 
   getAddress(address) {
-    return address & 0x7ffffff;
+    return address & 0x3ffffff;
+  }
+
+  isAddressReference(address) {
+    return address & MEMORY_FLAGS.ADDRESS_REFERENCE;
   }
 
   getAddressDebug(address) {

--- a/src/memory.js
+++ b/src/memory.js
@@ -2,16 +2,18 @@ class Memory {
   constructor(start, type) {
     this.start = start;
     this.current = start;
-    // our mask is 0x7FFFFFF, so one less is 0x7FFFFFE
-    this.end = start + 0x7fffffe;
+    // our mask is 0x3FFFFFF, so one less is 0x3FFFFFE
+    this.end = start + 0x3fffffe;
     this.type = type;
   }
 
-  getAddress(size = 1) {
+  allocateAddress(size = 1, flags) {
+    // flags will only apply to first address
+    // *should not be an issue*
     if (this.current < this.end) {
       const address = this.current;
       this.current += size;
-      return address;
+      return address | flags;
     }
     throw new Error('No more memory available');
   }

--- a/src/quadruples-manager.js
+++ b/src/quadruples-manager.js
@@ -32,6 +32,10 @@ class QuadruplesManager {
     this.quadruples.push(quadruple);
   }
 
+  pushALoad(baseAddress, offset, address) {
+    this.pushQuadruple([OPCODES.ALOAD, baseAddress, offset, address]);
+  }
+
   pushLoad(data, address) {
     this.pushQuadruple([OPCODES.LOAD, data, null, address]);
   }
@@ -44,12 +48,8 @@ class QuadruplesManager {
     this.pushQuadruple([OPERATORS.ASSIGN, left, right, target]);
   }
 
-  pushAddressOffsetAdd(origin, offset, target) {
-    this.pushQuadruple([OPCODES.ADDROFF_ADD, origin, offset, target]);
-  }
-
-  pushAddressOffsetMultiply(origin, offset, target) {
-    this.pushQuadruple([OPCODES.ADDROFF_MULTIPLY, origin, offset, target]);
+  pushOperator(operator, left, right, target) {
+    this.pushQuadruple([operator, left, right, target]);
   }
 
   pushCall(to) {

--- a/src/scope-manager.js
+++ b/src/scope-manager.js
@@ -132,12 +132,12 @@ class ScopeManager {
     this.scope = this.getParentScope(this.scope) ?? this.scope;
   }
 
-  malloc(memoryType, dataType, size) {
+  malloc(memoryType, dataType, size, flags) {
     const memory = this.getMemoryManager().getMemorySegment(
       memoryType,
       dataType
     );
-    return memory.getAddress(size);
+    return memory.allocateAddress(size, flags);
   }
 
   getTTO(leftAddress, rightAddress, operator) {

--- a/tests/files/test1.jpp
+++ b/tests/files/test1.jpp
@@ -4,7 +4,7 @@ var int arr[1], arr1[2][10];
 var string text1, text2;
 
 func int test() {
-    return 1 + 1;
+    return arr1[arr[0]][0];
 }
 
 func void test2(string a, int b) {

--- a/tests/files/test4.jpp
+++ b/tests/files/test4.jpp
@@ -4,10 +4,11 @@
 var int mat[2][10];
 
 program TEST_4 {
-    var int i, j;
+    var int i, j, l;
     for (i = 0; i < 2; i = i + 1) {
         for (j = 0; j < 10; j = j + 1) {
             mat[i][j] = i*j;
+            l = mat[i][j];
         }
     }
 }


### PR DESCRIPTION
An issue that we encountered was that we had the base address and we knew how much we needed to offset from that address to access the value from an array, but we didn't have a way to distinguish an address reference from a global variable.

A flag was added called ADDRESS_REFERENCE that lives in the 27th bit of the address. When it's turned to 1, it will indicate that the address references another address and not a direct variable.

This could possibly be refactored and improved but this was the initial approach and it works well for now.

When we want to pop an operand from the stack and it's an address reference, if we want to do an assignment, it will insert the assignment with the opcode ASTORE. If it's not an assignment and we want to access the variable, it will insert an ALOAD operation and return that address.